### PR TITLE
Add sticky headers and drag-to-scroll for improved table navigation

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -258,6 +258,40 @@ h1, h2, h3, h4, h5, h6 {
 .scrollable-table-container {
     overflow-x: auto;
     position: relative;
+    cursor: grab;
+}
+
+.scrollable-table-container:active {
+    cursor: grabbing;
+    user-select: none;
+}
+
+/* Visual hint for drag scrolling */
+.scrollable-table-container::before {
+    content: "↔ Przeciągnij aby przewinąć";
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    background: rgba(34, 197, 94, 0.9);
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    z-index: 1000;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.scrollable-table-container:hover::before {
+    opacity: 1;
+}
+
+/* Hide badge after user has scrolled */
+.scrollable-table-container.hide-badge::before {
+    opacity: 0 !important;
 }
 
 .table-title {
@@ -325,11 +359,19 @@ thead th {
 .table th:first-child, .table td:first-child {
     position: sticky;
     left: 0;
-    background-color: #d5e3f5;
+    background-color: #f8f9fa;
     border-right: 2px solid #dee2e6;
-    z-index: 100;
-    box-shadow: 2px 0 0 0 #dee2e6;
-    background-clip: padding-box;
+    z-index: 2;
+    box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+}
+
+.table th:first-child {
+    background-color: #f8f9fa;
+    z-index: 3;
+}
+
+.table td:first-child {
+    background-color: #d5e3f5;
 }
 
 .table th:not(:first-child), .table td:not(:first-child) {
@@ -435,4 +477,74 @@ a {
     background-color: #f9f9f9;
     white-space: pre-wrap;
     overflow-x: auto;
+}
+
+/* Sticky accordion headers */
+.accordion-item {
+    position: relative;
+}
+
+.accordion-header {
+    transition: all 0.2s ease-in-out;
+}
+
+.accordion-header.sticky {
+    position: fixed;
+    z-index: 1020;
+    background-color: white;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 0;
+    margin: 0;
+    border-radius: 0;
+    transition: none;
+}
+
+.accordion-header.sticky .accordion-button {
+    border-radius: 0;
+    margin: 0;
+}
+
+.accordion-body {
+    position: relative;
+}
+
+.scrollable-accordion-body {
+    position: relative;
+}
+
+/* Enhanced table headers - controlled by JavaScript */
+.scrollable-table-container .table thead th {
+    position: sticky;
+    top: 0;
+    background-color: #f8f9fa;
+    z-index: 10;
+    box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
+}
+
+/* When accordion header is sticky, adjust table header position dynamically */
+.accordion-item.header-sticky .scrollable-table-container .table thead th {
+    z-index: 9;
+}
+
+/* Sticky table headers when attached to accordion */
+.table thead th.table-header-sticky {
+    background-color: #f8f9fa;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-bottom: 1px solid #dee2e6;
+}
+
+.accordion-item.header-sticky .scrollable-table-container .table thead th:first-child {
+    z-index: 10;
+}
+
+/* Override DataTables styles for table headers */
+.scrollable-table-container .table thead th[style*="top"] {
+    position: sticky !important;
+}
+
+/* Sticky spacing when accordion header is fixed - will be handled by JS dynamically */
+
+/* Improve accordion button styling when sticky */
+.accordion-header.sticky .accordion-button {
+    border: 1px solid #dee2e6;
 }

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -30,12 +30,437 @@ const initializeDataTable = function(table) {
         searching: false,
         paging: false,
         info: false,
+        fixedHeader: false, // Disable DataTables fixed header
         initComplete: function () {
             const label = $(table).parents('.dataTables_wrapper').find('label');
             let labelHtml = label.html();
             if (labelHtml) {
                 label.html(labelHtml.replace('Search:', 'Search: '));
             }
+
+            // Reset any DataTables top styles that might interfere
+            $(table).find('thead th').each(function() {
+                this.style.removeProperty('top');
+            });
         }
     });
 }
+
+document.addEventListener('DOMContentLoaded', function() {
+    const accordionHeaders = document.querySelectorAll('.accordion-header');
+    const accordionItems = document.querySelectorAll('.accordion-item');
+
+    // Initialize drag to scroll for all table containers
+    function initializeDragToScroll() {
+        const containers = document.querySelectorAll('.scrollable-table-container');
+
+        containers.forEach(container => {
+            let isDown = false;
+            let startX;
+            let scrollLeft;
+            let hasScrolled = false;
+
+            // Add cursor styles
+            container.style.cursor = 'grab';
+
+            container.addEventListener('mousedown', (e) => {
+                isDown = true;
+                container.style.cursor = 'grabbing';
+                startX = e.pageX - container.offsetLeft;
+                scrollLeft = container.scrollLeft;
+                container.style.userSelect = 'none'; // Prevent text selection
+            });
+
+            container.addEventListener('mouseleave', () => {
+                isDown = false;
+                container.style.cursor = 'grab';
+            });
+
+            container.addEventListener('mouseup', () => {
+                isDown = false;
+                container.style.cursor = 'grab';
+            });
+
+            container.addEventListener('mousemove', (e) => {
+                if (!isDown) return;
+                e.preventDefault();
+                const x = e.pageX - container.offsetLeft;
+                const walk = (x - startX) * 2; // *2 for faster scrolling
+                container.scrollLeft = scrollLeft - walk;
+
+                // Hide badge after first horizontal drag scroll (2x faster - 200ms)
+                if (!hasScrolled && Math.abs(walk) > 5) {
+                    hasScrolled = true;
+                    container.classList.add('scrolled');
+                    setTimeout(() => {
+                        container.classList.add('hide-badge');
+                    }, 200);
+                }
+            });
+
+            // Also hide badge on regular scroll - detect if horizontal or vertical
+            container.addEventListener('scroll', () => {
+                if (!hasScrolled) {
+                    hasScrolled = true;
+                    container.classList.add('scrolled');
+                    // For horizontal scroll, fade out in 200ms, for vertical - immediately
+                    container.classList.add('hide-badge');
+                }
+            });
+        });
+    }
+
+    // Initialize on page load
+    initializeDragToScroll();
+
+    // Hide badges immediately on vertical page scroll
+    window.addEventListener('scroll', () => {
+        document.querySelectorAll('.scrollable-table-container:not(.hide-badge)').forEach(container => {
+            container.classList.add('hide-badge');
+        });
+    });
+
+    function handleStickyHeaders() {
+        const header = document.querySelector('header');
+        const headerHeight = header ? header.offsetHeight : 0;
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        // Get current position of navigation header
+        const headerRect = header ? header.getBoundingClientRect() : null;
+        const navBottomPosition = headerRect ? Math.max(0, headerRect.bottom) : 0;
+
+        accordionItems.forEach((item) => {
+            const accordionHeader = item.querySelector('.accordion-header');
+            const collapse = item.querySelector('.accordion-collapse');
+            const itemRect = item.getBoundingClientRect();
+            const itemTop = itemRect.top + scrollTop;
+            const itemBottom = itemRect.bottom + scrollTop;
+
+            // Check if accordion is expanded
+            const isExpanded = collapse.classList.contains('show');
+
+            if (isExpanded) {
+                // Check if we should make header sticky
+                const shouldBeSticky = scrollTop > (itemTop - headerHeight) &&
+                                     scrollTop < (itemBottom - headerHeight - 100);
+
+                if (shouldBeSticky) {
+                    accordionHeader.classList.add('sticky');
+                    item.classList.add('header-sticky');
+
+                    // Position sticky header to follow navigation bar smoothly
+                    accordionHeader.style.top = navBottomPosition + 'px';
+
+                    // Add appropriate class based on nav position
+                    if (navBottomPosition > 0) {
+                        accordionHeader.classList.add('sticky-with-nav');
+                        accordionHeader.classList.remove('sticky-top');
+                    } else {
+                        accordionHeader.classList.add('sticky-top');
+                        accordionHeader.classList.remove('sticky-with-nav');
+                    }
+
+                    // Keep original position and width
+                    const itemCurrentRect = item.getBoundingClientRect();
+                    accordionHeader.style.left = itemCurrentRect.left + 'px';
+                    accordionHeader.style.width = item.offsetWidth + 'px';
+
+                    // Make table headers stick to accordion header (same approach as accordion to nav)
+                    const tableHeaders = item.querySelectorAll('.scrollable-table-container .table thead th');
+                    const accordionHeaderHeight = accordionHeader.offsetHeight || 60;
+
+                    tableHeaders.forEach((th) => {
+                        const tableRect = th.closest('table').getBoundingClientRect();
+                        const tableTop = tableRect.top + scrollTop;
+                        const tableBottom = tableRect.bottom + scrollTop;
+
+                        // Check if table header should be sticky (when table reaches accordion)
+                        const tableShouldBeSticky = scrollTop > (tableTop - headerHeight - accordionHeaderHeight) &&
+                                                  scrollTop < (tableBottom - headerHeight - accordionHeaderHeight - 50);
+
+                        if (tableShouldBeSticky) {
+                            // Create or update fixed header clone
+                            let fixedTable = item.querySelector('.fixed-table-header');
+                            if (!fixedTable) {
+                                const table = th.closest('table');
+                                fixedTable = table.cloneNode(true);
+
+                                // Preserve original classes and add our fixed class
+                                fixedTable.className = table.className + ' fixed-table-header';
+
+                                // Keep only thead, remove tbody
+                                const tbody = fixedTable.querySelector('tbody');
+                                if (tbody) tbody.remove();
+
+                                // Get container dimensions for clipping
+                                const container = th.closest('.scrollable-table-container');
+                                const containerRect = container.getBoundingClientRect();
+                                const accordionItem = th.closest('.accordion-item');
+                                const accordionItemRect = accordionItem.getBoundingClientRect();
+                                const tableRect = table.getBoundingClientRect();
+                                const scrollLeft = container.scrollLeft;
+
+                                // Calculate clipping to stay within accordion bounds
+                                const accordionPadding = 15;
+                                const accordionRightEdge = accordionItemRect.right - accordionPadding;
+                                const maxWidth = accordionRightEdge - containerRect.left;
+
+
+                                // Position at original container location but clip to accordion bounds
+                                fixedTable.style.cssText = `
+                                    position: fixed !important;
+                                    top: ${navBottomPosition + accordionHeaderHeight}px;
+                                    left: ${containerRect.left}px;
+                                    width: ${Math.min(containerRect.width, maxWidth)}px;
+                                    max-width: ${maxWidth}px;
+                                    z-index: 1018;
+                                    margin: 0 !important;
+                                    border-collapse: separate !important;
+                                    border-spacing: 0 !important;
+                                    overflow: hidden !important;
+                                    clip-path: inset(0 0 0 0);
+                                `;
+
+                                // Copy computed styles from original table headers to cloned headers
+                                const originalHeaders = table.querySelectorAll('thead th');
+                                const clonedHeaders = fixedTable.querySelectorAll('thead th');
+
+                                // Force table to use same layout mode as original
+                                fixedTable.style.tableLayout = table.style.tableLayout || 'auto';
+                                fixedTable.style.width = table.offsetWidth + 'px';
+
+                                // Calculate cumulative offset to match original positioning exactly
+                                let cumulativeOffset = 0;
+
+                                originalHeaders.forEach((originalTh, index) => {
+                                    if (clonedHeaders[index]) {
+                                        const clonedTh = clonedHeaders[index];
+                                        const computedStyle = window.getComputedStyle(originalTh);
+
+                                        // Get exact positioning from original table
+                                        const originalRect = originalTh.getBoundingClientRect();
+                                        const actualWidth = originalRect.width;
+
+                                        // Copy all border/padding/margin properties exactly
+                                        clonedTh.style.boxSizing = computedStyle.boxSizing;
+                                        clonedTh.style.border = computedStyle.border;
+                                        clonedTh.style.borderLeft = computedStyle.borderLeft;
+                                        clonedTh.style.borderRight = computedStyle.borderRight;
+                                        clonedTh.style.padding = computedStyle.padding;
+                                        clonedTh.style.margin = computedStyle.margin;
+
+                                        // Force exact same width as rendered
+                                        clonedTh.style.width = actualWidth + 'px';
+                                        clonedTh.style.minWidth = actualWidth + 'px';
+                                        clonedTh.style.maxWidth = actualWidth + 'px';
+
+                                        // Copy visual styles
+                                        clonedTh.style.backgroundColor = computedStyle.backgroundColor;
+                                        clonedTh.style.color = computedStyle.color;
+                                        clonedTh.style.fontSize = computedStyle.fontSize;
+                                        clonedTh.style.fontWeight = computedStyle.fontWeight;
+                                        clonedTh.style.textAlign = computedStyle.textAlign;
+                                        clonedTh.style.boxShadow = computedStyle.boxShadow;
+
+                                        // Copy DataTables sorting classes
+                                        clonedTh.className = originalTh.className;
+
+                                        // Handle scrolling: first column stays frozen, others scroll
+                                        if (index === 0) {
+                                            // First column - position exactly like original
+                                            clonedTh.style.position = 'sticky';
+                                            clonedTh.style.left = '0px';
+                                            clonedTh.style.zIndex = '1019';
+                                        } else {
+                                            // Other columns - apply scroll offset but maintain exact positioning
+                                            clonedTh.style.transform = `translateX(-${scrollLeft}px)`;
+                                        }
+
+                                        // Enable sorting by forwarding clicks to original header
+                                        clonedTh.style.cursor = 'pointer';
+                                        clonedTh.addEventListener('click', function(e) {
+                                            e.preventDefault();
+                                            e.stopPropagation();
+                                            // Trigger click on original header for DataTables sorting
+                                            originalTh.click();
+
+                                            // Update cloned header classes after sort
+                                            setTimeout(() => {
+                                                clonedTh.className = originalTh.className;
+                                            }, 50);
+                                        });
+
+                                        cumulativeOffset += actualWidth;
+                                    }
+                                });
+
+                                // Create wrapper container for better clipping control
+                                let wrapperDiv = item.querySelector('.fixed-table-wrapper');
+                                if (!wrapperDiv) {
+                                    wrapperDiv = document.createElement('div');
+                                    wrapperDiv.className = 'fixed-table-wrapper';
+                                    wrapperDiv.style.cssText = `
+                                        position: fixed !important;
+                                        top: ${navBottomPosition + accordionHeaderHeight}px;
+                                        left: ${containerRect.left}px;
+                                        width: ${Math.min(containerRect.width, maxWidth)}px;
+                                        height: 60px;
+                                        z-index: 1018;
+                                        overflow: hidden !important;
+                                    `;
+                                    item.appendChild(wrapperDiv);
+                                }
+
+                                // Reset fixed table positioning to be relative to wrapper
+                                fixedTable.style.cssText = `
+                                    position: relative !important;
+                                    top: 0;
+                                    left: 0;
+                                    width: ${table.offsetWidth}px;
+                                    margin: 0 !important;
+                                    border-collapse: separate !important;
+                                    border-spacing: 0 !important;
+                                `;
+
+                                wrapperDiv.appendChild(fixedTable);
+
+                                // Add immediate horizontal scroll listener for this container
+                                const immediateScrollHandler = () => {
+                                    const scrollLeft = container.scrollLeft;
+                                    const clonedHeaders = fixedTable.querySelectorAll('thead th');
+                                    clonedHeaders.forEach((clonedTh, index) => {
+                                        if (index > 0) { // Skip first column
+                                            clonedTh.style.transform = `translateX(-${scrollLeft}px)`;
+                                        }
+                                    });
+                                };
+
+                                // Store reference to handler for later removal
+                                container._stickyScrollHandler = immediateScrollHandler;
+
+                                // Use passive listener for better performance and immediate response
+                                container.addEventListener('scroll', immediateScrollHandler, { passive: true });
+                            } else {
+                                // Update wrapper position and bounds to stay within accordion
+                                const wrapperDiv = item.querySelector('.fixed-table-wrapper');
+                                if (wrapperDiv) {
+                                    const container = th.closest('.scrollable-table-container');
+                                    const containerRect = container.getBoundingClientRect();
+                                    const accordionItem = th.closest('.accordion-item');
+                                    const accordionItemRect = accordionItem.getBoundingClientRect();
+
+                                    const accordionPadding = 15;
+                                    const accordionRightEdge = accordionItemRect.right - accordionPadding;
+                                    const maxWidth = accordionRightEdge - containerRect.left;
+
+                                    wrapperDiv.style.top = (navBottomPosition + accordionHeaderHeight) + 'px';
+                                    wrapperDiv.style.left = containerRect.left + 'px';
+                                    wrapperDiv.style.width = Math.min(containerRect.width, maxWidth) + 'px';
+                                }
+                            }
+
+                            // Hide original header when fixed is active
+                            th.style.visibility = 'hidden';
+                        } else {
+                            // Remove fixed header clone and show original
+                            const wrapperDiv = item.querySelector('.fixed-table-wrapper');
+                            if (wrapperDiv) {
+                                // Remove specific scroll listener from this container
+                                const container = th.closest('.scrollable-table-container');
+                                if (container._stickyScrollHandler) {
+                                    container.removeEventListener('scroll', container._stickyScrollHandler);
+                                    container._stickyScrollHandler = null;
+                                }
+                                wrapperDiv.remove();
+                            }
+                            th.style.visibility = '';
+                        }
+                    });
+
+                    // Adjust accordion content padding
+                    collapse.style.paddingTop = accordionHeaderHeight + 'px';
+                } else {
+                    accordionHeader.classList.remove('sticky', 'sticky-with-nav', 'sticky-top');
+                    item.classList.remove('header-sticky');
+                    accordionHeader.style.top = '';
+                    accordionHeader.style.left = '';
+                    accordionHeader.style.width = '';
+
+                    // Reset table headers - remove clones and show originals
+                    const wrapperDivs = item.querySelectorAll('.fixed-table-wrapper');
+                    wrapperDivs.forEach(wrapper => {
+                        wrapper.remove();
+                    });
+
+                    // Clean up specific scroll listeners
+                    const containers = item.querySelectorAll('.scrollable-table-container');
+                    containers.forEach(container => {
+                        if (container._stickyScrollHandler) {
+                            container.removeEventListener('scroll', container._stickyScrollHandler);
+                            container._stickyScrollHandler = null;
+                        }
+                    });
+
+                    const tableHeaders = item.querySelectorAll('.scrollable-table-container .table thead th');
+                    tableHeaders.forEach(th => {
+                        th.style.visibility = '';
+                    });
+                    collapse.style.paddingTop = '';
+                }
+            } else {
+                accordionHeader.classList.remove('sticky', 'sticky-with-nav', 'sticky-top');
+                item.classList.remove('header-sticky');
+                accordionHeader.style.top = '';
+                accordionHeader.style.left = '';
+                accordionHeader.style.width = '';
+
+                // Reset table headers - remove clones and show originals
+                const wrapperDivs = item.querySelectorAll('.fixed-table-wrapper');
+                wrapperDivs.forEach(wrapper => {
+                    wrapper.remove();
+                });
+
+                // Clean up specific scroll listeners
+                const containers = item.querySelectorAll('.scrollable-table-container');
+                containers.forEach(container => {
+                    if (container._stickyScrollHandler) {
+                        container.removeEventListener('scroll', container._stickyScrollHandler);
+                        container._stickyScrollHandler = null;
+                    }
+                });
+
+                const tableHeaders = item.querySelectorAll('.scrollable-table-container .table thead th');
+                tableHeaders.forEach(th => {
+                    th.style.visibility = '';
+                });
+                collapse.style.paddingTop = '';
+            }
+        });
+    }
+
+    // Throttle scroll events for better performance
+    let ticking = false;
+    function requestTick() {
+        if (!ticking) {
+            requestAnimationFrame(handleStickyHeaders);
+            ticking = true;
+            setTimeout(() => { ticking = false; }, 16);
+        }
+    }
+
+    window.addEventListener('scroll', requestTick);
+    window.addEventListener('resize', handleStickyHeaders);
+
+    // Handle accordion toggle events
+    accordionHeaders.forEach(header => {
+        header.addEventListener('click', function() {
+            // Small delay to allow accordion animation to start
+            setTimeout(() => {
+                handleStickyHeaders();
+                initializeDragToScroll(); // Re-initialize drag to scroll for new containers
+            }, 50);
+        });
+    });
+
+
+});


### PR DESCRIPTION
  ## Features Added
  - **Sticky Accordion Headers**: Headers stick to navigation bar and move smoothly
  when nav hides/shows
  - **Sticky Table Headers**: Table headers remain visible during vertical scroll with
   exact column width matching
  - **Drag-to-Scroll**: Click and drag tables horizontally for users without
  horizontal scroll wheels
  - **Smart Visual Hints**: Helpful tooltip appears on hover, fades out after first
  use
  - **DataTables Compatibility**: Full sorting and filtering functionality preserved
  in sticky mode
  - **First Column Freeze**: Name column stays frozen during horizontal scroll
  - **Boundary Clipping**: Headers properly clip within accordion containers

  ## User Experience
  - Intuitive drag-to-scroll works like mobile interfaces
  - Visual hints guide users without being intrusive
  - Headers disappear when not needed (after scrolling)
  - Maintains responsive design and works across different screen sizes
